### PR TITLE
Optimize Makefile for downstream packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 #
 
 # Set to where you'd like grepcidr installed
+INSTALL=install
 INSTALLDIR=/usr/local
 INSTALLDIR_BIN=${INSTALLDIR}/bin
 INSTALLDIR_MAN=${INSTALLDIR}/man/man1
@@ -22,11 +23,11 @@ DIR := $(shell basename ${PWD})
 all:	grepcidr
 
 grepcidr:	grepcidr.c
-	$(CC) $(CFLAGS) -o grepcidr grepcidr.c
+	$(CC) $(CFLAGS) $(RPM_OPT_FLAGS) $(RPM_LD_FLAGS) -o grepcidr grepcidr.c
 
 install:	all  grepcidr.1
-	install grepcidr $(INSTALLDIR_BIN)
-	install -m 0644 grepcidr.1 $(INSTALLDIR_MAN)
+	$(INSTALL) grepcidr $(DESTDIR)$(INSTALLDIR_BIN)
+	$(INSTALL) -m 0644 grepcidr.1 $(DESTDIR)$(INSTALLDIR_MAN)
 
 clean:
 	rm -f grepcidr


### PR DESCRIPTION
Some Linux distributions prefer to use `INSTALL='install -p'` during `make install` to preserve the original file timestamps when packaging grepcidr3.

Additionally, when building as RPM, `$RPM_OPT_FLAGS` and `$RPM_LD_FLAGS` are populated during build-time as well as `$DESTDIR` during installation time.